### PR TITLE
(feat): Add support for building on CentOS 8

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "8" ]
+  pull_request:
+    branches: [ "8" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)


### PR DESCRIPTION
The RPM packages built on CentOS 7 contain MD5 and SHA1 payload digests, which make the RPMs non-installable on FIPS-enabled servers running RHEL/CentOS/Rocky/Alma Linux 8.

As a precursor for twindb-backup RPM building, this PR bumps the container image for omnibus-centos so that `rpm >= 4.14` is included, which generates the necessary SHA256 payload digests _I've already validated the building of twindb-backup RPMs using this image, but before submitting a PR for the twindb/backup repository, will need to ensure this PR merges, and a new image for `twindb/omnibus-centos:8` is pushed to the container registry_

A small snippet of the local build:
```
 [Project: twindb-backup] I | 2024-03-23T06:07:02+00:00 | Building version manifest
            [HealthCheck] I | 2024-03-23T06:07:02+00:00 | Running health on twindb-backup
            [HealthCheck] I | 2024-03-23T06:07:11+00:00 | Health check time: 9.4311s
          [Packager::RPM] I | 2024-03-23T06:07:14+00:00 | Rendering `/usr/local/rvm/gems/ruby-3.0.0/gems/omnibus-9.0.11/resources/rpm/spec.erb' to `/tmp/twindb-backup20240323-559-7qb0mv/SPECS/twindb-backup-3.3.0-1.x86_64.rpm.spec'
          [Packager::RPM] I | 2024-03-23T06:07:14+00:00 | Creating .rpm file
```

followed by validation of the RPM file containing the necessary payload info:

```
/backup/omnibus/pkg# rpm --checksig -v twindb-backup-3.3.0-1.x86_64.rpm
twindb-backup-3.3.0-1.x86_64.rpm:
    Header SHA256 digest: OK
    Header SHA1 digest: OK
    Payload SHA256 digest: OK
    MD5 digest: OK
```

*I'm guessing you'll want a new branch called `8` to keep with the naming conventions here.